### PR TITLE
Track GitLab Project IDs

### DIFF
--- a/ops.yml
+++ b/ops.yml
@@ -1,7 +1,7 @@
 version: # Defines the used `ops.yml` schema version
   "1"
 commands:
-  - name: gitlab:1.0.0
+  - name: gitlab:1.1.0
     public: true
     sourceCodeURL: "https://github.com/cto-ai/gitlab"
     description: # Short description for what your op does (required)

--- a/src/commands/project:clone.ts
+++ b/src/commands/project:clone.ts
@@ -12,14 +12,14 @@ export const projectClone = async options => {
   try {
     await setToken()
     const { username } = await getUser()
-    const { name, namespace, url } = await selectProject()
+    const { name, namespace, url, id } = await selectProject()
     const urlWithToken = await insertTokenInUrl(
       url,
       options.accessToken,
       username,
     )
     await cloneProject(urlWithToken)
-    await saveProjectToConfig(namespace, name, username)
+    await saveProjectToConfig(namespace, name, username, id)
     await handleSuccess('project:clone', { name })
   } catch (err) {
     await handleError(err, 'project:clone')

--- a/src/commands/project:create.ts
+++ b/src/commands/project:create.ts
@@ -36,6 +36,7 @@ export const projectCreate = async ({ accessToken }) => {
       http_url_to_repo,
       path_with_namespace,
       namespace: { full_path },
+      id,
     } = await createProject(answers)
 
     // add labels to the repo
@@ -54,7 +55,7 @@ export const projectCreate = async ({ accessToken }) => {
     }
 
     // set config
-    saveProjectToConfig(full_path, name, username)
+    saveProjectToConfig(full_path, name, username, id)
     await fs.ensureDir(`${name}`)
 
     // copies select template files

--- a/src/prompts/project:clone.ts
+++ b/src/prompts/project:clone.ts
@@ -14,6 +14,7 @@ const formatList = async () => {
       http_url_to_repo,
       namespace: { full_path },
       path,
+      id,
     } = project
     if (isProjectCloned(full_path, path, remoteProjects)) {
       return {
@@ -22,6 +23,7 @@ const formatList = async () => {
           name: path,
           url: http_url_to_repo,
           namespace: full_path,
+          id,
         },
       }
     }
@@ -31,6 +33,7 @@ const formatList = async () => {
         name: path,
         url: http_url_to_repo,
         namespace: full_path,
+        id,
       },
     }
   })

--- a/src/types/Projects.ts
+++ b/src/types/Projects.ts
@@ -2,6 +2,7 @@ export interface Project {
   name: string
   namespace: string
   url?: string
+  id: number
 }
 
 export interface RemoteProject {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -54,11 +54,13 @@ export const logProvideCmdMsg = async commands => {
  * @param namespace project namespace
  * @param name project name
  * @param username GitLab username
+ * @param id project id
  */
 export const saveProjectToConfig = async (
   namespace: string,
   name: string,
   username: string,
+  id: number,
 ): Promise<string> => {
   try {
     const oldRemoteRepos = (await getConfig('remoteRepos')) || []
@@ -70,6 +72,7 @@ export const saveProjectToConfig = async (
         namespace,
         repo: name,
         url,
+        id,
       },
     ]
     await setConfig('remoteRepos', remoteRepos)
@@ -164,7 +167,8 @@ export const checkCurrentProject = async (cmdOptions: CommandOptions) => {
       } else {
         const { namespace, repo } = filterForProjectInfo(originUrl)
         const { username } = await getUser()
-        const url = await saveProjectToConfig(namespace, repo, username)
+        const { id } = await getProject(`${namespace}/${repo}`)
+        const url = await saveProjectToConfig(namespace, repo, username, id)
         await pExec(`git remote set-url origin ${url}`)
         cmdOptions.currentRepo = { namespace, repo, url }
       }
@@ -210,10 +214,12 @@ export const formatProjectList = (projects: GitLabProjectRes[]): Project[] => {
     const {
       path,
       namespace: { full_path },
+      id,
     } = project
     return {
       name: path,
       namespace: full_path,
+      id,
     }
   })
 }


### PR DESCRIPTION
Adds an additional `id` field to track the GitLab project id for each repo saved in the remoteRepo list in the config.

@jplew